### PR TITLE
Fixed #1

### DIFF
--- a/lua/norme.lua
+++ b/lua/norme.lua
@@ -6,6 +6,7 @@ local diagnostic_skeleton = { source = 'norminette', severity = ERROR }
 local stdin_parser = '../utils/stdin-parser'
 
 local parser = function(output)
+	print(output)
 	local result = vim.fn.split(output, "\n")
 	local diagnostics = {}
 


### PR DESCRIPTION
Closes #1  (HACK)

Added a fallback in case `stdin-parser` does not receive args. It is an issue with `nvim-lint`.