### PR TITLE
fix: randomize file name before linting

### DIFF
--- a/utils/stdin-parser
+++ b/utils/stdin-parser
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-FILENAME="$1"
+PREFIX="$(tr -dc a-z </dev/urandom | head -c 32)"
+
+FILENAME="$PREFIX$1"
 TEMP_FILE="/tmp/$FILENAME"
 
-cat > "$TEMP_FILE"
+GUARD_NAME="$(echo "$1" | tr "[:lower:]." "[:upper:]_")"
+PREFIXED_GUARD_NAME="$(echo "$FILENAME" | tr "[:lower:]." "[:upper:]_")"
+
+cat | sed "s/$GUARD_NAME/$PREFIXED_GUARD_NAME/g" > "$TEMP_FILE"
 norminette "$TEMP_FILE"
 rm "$TEMP_FILE"


### PR DESCRIPTION
fixes #4 by randomizing the name of the files that it will lint. If it's a .h file, it will change it's contents to make the inclusion guard match the file name.